### PR TITLE
crosscompiling plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 lazy val commonSettings: Seq[Setting[_]] = Seq(
-  git.baseVersion in ThisBuild := "1.0.0",
+  git.baseVersion in ThisBuild := "2.0.0",
   organization in ThisBuild := "org.idio"
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -12,12 +12,14 @@ lazy val root = (project in file(".")).
     description := "sbt assembly plugin merge strategy for log4j2 plugins",
     licenses := Seq("MIT License" -> url("https://github.com/idio/sbt-assembly-log4j2/blob/master/LICENSE")),
     scalacOptions := Seq("-deprecation", "-unchecked"),
-    addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.4"),
+    addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10"),
     libraryDependencies ++= Seq(
       "org.apache.logging.log4j" % "log4j-core" % "2.8.1"
     ),
+    crossSbtVersions := Seq("0.13.16", "1.2.8"),
+    crossScalaVersions := Seq("2.11.8", "2.12.10"),   
     publishArtifact in (Compile, packageBin) := true,
     publishArtifact in (Test, packageBin) := false,
     publishArtifact in (Compile, packageDoc) := false,
-    publishArtifact in (Compile, packageSrc) := true
+    publishArtifact in (Compile, packageSrc) := true,
   )

--- a/project/bintray.sbt
+++ b/project/bintray.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.6")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=1.2.8

--- a/project/git.sbt
+++ b/project/git.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")


### PR DESCRIPTION
[ch73835]

This PR makes this plugin to be compiled and published for sbt 0.13.X and 0.1.X.
we are bumping sbt version in fandango's related repos, flashlight is using this plugin.

when rolling out we have to run `^publish` to  publish and compile for all named versions, this is the update in docs https://github.com/idio/docs/pull/994
