### PR TITLE
Adapt plugincache MergeStrategy to sbt-assembly:2.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 lazy val commonSettings: Seq[Setting[_]] = Seq(
-  git.baseVersion in ThisBuild := "2.0.1",
+  git.baseVersion in ThisBuild := "2.1.0",
   organization in ThisBuild := "org.idio"
 )
 
@@ -12,9 +12,9 @@ lazy val root = (project in file(".")).
     description := "sbt assembly plugin merge strategy for log4j2 plugins",
     licenses := Seq("MIT License" -> url("https://github.com/idio/sbt-assembly-log4j2/blob/master/LICENSE")),
     scalacOptions := Seq("-deprecation", "-unchecked"),
-    addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10"),
+    addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.0.0-RC1"),
     libraryDependencies ++= Seq(
-      "org.apache.logging.log4j" % "log4j-core" % "2.8.1"
+      "org.apache.logging.log4j" % "log4j-core" % "2.17.2"
     ),
     crossSbtVersions := Seq("0.13.16", "1.2.8"),
     crossScalaVersions := Seq("2.11.8", "2.12.10"),   

--- a/src/main/scala/sbtassembly/Log4j2MergeStrategy.scala
+++ b/src/main/scala/sbtassembly/Log4j2MergeStrategy.scala
@@ -1,29 +1,32 @@
 package sbtassembly
 
-import java.io.{FileOutputStream, File}
+import org.apache.logging.log4j.core.config.plugins.processor.PluginCache
+import sbt.IO
+import sbt.io.Using
+import sbtassembly.Assembly.JarEntry
 
+import java.io.{BufferedInputStream, FileInputStream, FileOutputStream}
+import java.util.UUID
 import scala.collection.JavaConverters.asJavaEnumerationConverter
 
-import org.apache.logging.log4j.core.config.plugins.processor.PluginCache
-
 object Log4j2MergeStrategy {
-  val plugincache: MergeStrategy = new MergeStrategy {
-    val name = "log4j2::plugincache"
-    def apply(tempDir: File, path: String, files: Seq[File]): Either[String, Seq[(File, String)]] = {
-      val file = MergeStrategy.createMergeTarget(tempDir, path)
-      val out = new FileOutputStream(file)
-
-      val aggregator = new PluginCache()
-      val filesEnum = files.toIterator.map(_.toURI.toURL).asJavaEnumeration
-
-      try {
-          aggregator.loadCacheFiles(filesEnum)
-          aggregator.writeCache(out)
-          Right(Seq(file -> path))
+  val plugincache: MergeStrategy = MergeStrategy("log4j2::plugincache", 2) { dependencies =>
+    val DatFileExt = ".dat"
+    val (datFiles, datURIs) = dependencies.map { dep =>
+      IO.withTemporaryFile(UUID.randomUUID().toString, DatFileExt, true) { datFile =>
+        IO.transfer(dep.stream(), datFile)
+        datFile -> datFile.toURI.toURL
       }
-      finally {
-          out.close()
+    }.unzip
+
+    val stream = IO.withTemporaryFile(UUID.randomUUID().toString, DatFileExt, true) { mergedDatFile =>
+      Using.bufferedOutputStream(new FileOutputStream(mergedDatFile)) { os =>
+        val aggregator = new PluginCache()
+        aggregator.loadCacheFiles(datURIs.toIterator.asJavaEnumeration)
+        aggregator.writeCache(os)
+        () => new BufferedInputStream(new FileInputStream(mergedDatFile))
       }
     }
+    Right(JarEntry(dependencies.head.target, stream) +: Vector.empty)
   }
 }


### PR DESCRIPTION
Update MergeStrategy code to use temp files to extract the InputStreams
Update the sbt assembly plugin to use 2.0.0-RC1
Update the log4j version to 2.17.2
Update version to 2.1.0

---

Hey maintainers, 

We need to update this for the upcoming sbt-assembly 2.0.0 (right now it's in RC1 mode)

**Background**

sbt-assembly has recently been [updated](https://github.com/sbt/sbt-assembly/pull/464) to use a streaming/in-memory model instead of IO/disk-extraction model. Due to this, the method signature of the `MergeStrategy` has changed.

I also went ahead and updated the log4j dependency to `2.17.2` to fix that infamous vulnerability.